### PR TITLE
Fix is_metric (changes "metric property" definition)

### DIFF
--- a/input_validator.py
+++ b/input_validator.py
@@ -7,7 +7,7 @@ import argparse
 import utils
 import networkx as nx
 import numpy as np
-from utils_sp18 import *
+# from utils_sp18 import *
 from student_utils_sp18 import *
 # import planarity
 

--- a/student_utils_sp18.py
+++ b/student_utils_sp18.py
@@ -40,13 +40,9 @@ def adjacency_matrix_to_graph(adjacency_matrix):
 
 
 def is_metric(G):
-    for i in G.nodes:
-        for j in G.nodes:
-            for k in G.nodes:
-                if i != j and j != k and i != k and G.has_edge(i, j) and G.has_edge(j, k) and G.has_edge(k, i):
-                    assert G.edges[i, j]['weight'] + G.edges[j, k]['weight'] > G.edges[k, i]['weight']
-                    assert G.edges[j, k]['weight'] + G.edges[k, i]['weight'] > G.edges[i, j]['weight']
-                    assert G.edges[k, i]['weight'] + G.edges[i, j]['weight'] > G.edges[j, k]['weight']
+    shortest = dict(nx.floyd_warshall(G))
+    for u, v, datadict in G.edges(data=True):
+        assert shortest[u][v] == datadict['weight'], 'Direct path from {} to {} (weight {}) is not shortest path (weight {})'.format(u, v, datadict['weight'], shortest[u][v])
     return True
 
 


### PR DESCRIPTION
This pull request would change what the spec means by "metric"

Currently it is possible to create a "non-metric" graph that obeys _the spec's and this checker's version_ of the "metric property." This is because the current code only considers triangles:
```
c(i, j) + c(j, k) > c(i, k)
```
(and also I think this should be `>=` not `>`)

This allows the following input, that has a path (a, b, c, d) shorter than (a, d). This graph has no triangles.
```
   _(1)__ [B] __(1)__ [C] __(1) _
  /                              \
[A]                              [D]
  \_____________(4)______________/   
```
```
4
A B C D
A
1 1 x 4
1 1 1 x
x 1 1 1
4 x 1 1 
```

We can modify the triangle property to be the following, where `d(i, j)` is the shortest path distance from `i` to `j`.
```
d(i, j) + d(j, k) >= c(i, k)
```

However, this is equivalent to `d(i, k) >= c(i, k)` which is equivalent to `d(i, k) == c(i, k)`.

This change makes sure graphs satisfy what I believe to be a better, _metric_, definition of a "metric property."